### PR TITLE
Change Create Parameters for SeL4 Support

### DIFF
--- a/keystone-ioctl.c
+++ b/keystone-ioctl.c
@@ -56,6 +56,11 @@ int keystone_finalize_enclave(unsigned long arg)
     create_args.utm_region.size = 0;
   }
 
+  // physical addresses for runtime, user, and freemem
+  create_args.runtime_paddr = epm_va_to_pa(enclave->epm, enclp->runtime_vaddr);
+  create_args.user_paddr = epm_va_to_pa(enclave->epm, enclp->user_vaddr);
+  create_args.free_paddr = epm_get_free_pa(enclave->epm);
+
   create_args.params = enclp->params;
 
   // SM will write the eid to enclave_t.eid

--- a/keystone-sbi-arg.h
+++ b/keystone-sbi-arg.h
@@ -19,6 +19,11 @@ struct keystone_sbi_create_t
   struct keystone_sbi_pregion_t epm_region;
   struct keystone_sbi_pregion_t utm_region;
 
+  // physical addresses
+  uintptr_t runtime_paddr;
+  uintptr_t user_paddr;
+  uintptr_t free_paddr;
+
   // Parameters
   struct runtime_params_t params;
 

--- a/keystone.h
+++ b/keystone.h
@@ -126,7 +126,9 @@ int utm_destroy(utm_t* utm);
 int utm_init(utm_t* utm, size_t untrusted_size);
 int epm_clean_free_list(epm_t* epm);
 int utm_clean_free_list(utm_t* utm);
-
+size_t epm_alloc_vspace(epm_t* epm, vaddr_t addr, size_t num_pages);
+paddr_t epm_va_to_pa(epm_t* epm, vaddr_t addr);
+paddr_t epm_get_free_pa(epm_t* epm);
 vaddr_t utm_alloc_page(utm_t* utm, epm_t* epm, vaddr_t addr, unsigned long flags);
 size_t epm_alloc_vspace(epm_t* epm, vaddr_t addr, size_t num_pages);
 vaddr_t epm_alloc_rt_page(epm_t* epm, vaddr_t addr);

--- a/keystone.h
+++ b/keystone.h
@@ -126,7 +126,6 @@ int utm_destroy(utm_t* utm);
 int utm_init(utm_t* utm, size_t untrusted_size);
 int epm_clean_free_list(epm_t* epm);
 int utm_clean_free_list(utm_t* utm);
-size_t epm_alloc_vspace(epm_t* epm, vaddr_t addr, size_t num_pages);
 paddr_t epm_va_to_pa(epm_t* epm, vaddr_t addr);
 paddr_t epm_get_free_pa(epm_t* epm);
 vaddr_t utm_alloc_page(utm_t* utm, epm_t* epm, vaddr_t addr, unsigned long flags);

--- a/keystone_user.h
+++ b/keystone_user.h
@@ -45,13 +45,17 @@ struct runtime_params_t {
 };
 
 struct keystone_ioctl_create_enclave {
-    __u64 eid;
+  __u64 eid;
 
-    //Min pages required
-    __u64 min_pages;
+  //Min pages required
+  __u64 min_pages;
 
-    // Runtime Parameters
-    struct runtime_params_t params;
+  // virtual addresses
+  __u64 runtime_vaddr;
+  __u64 user_vaddr;
+
+  // Runtime Parameters
+  struct runtime_params_t params;
 };
 
 struct keystone_ioctl_run_enclave {


### PR DESCRIPTION
The OS now passes the physical addresses of the enclave through
create SBI arguments.
+ Fixed a bug in CMA allocation