### PR TITLE
BUGFIX: remove duplicate include

### DIFF
--- a/keystone-ioctl.c
+++ b/keystone-ioctl.c
@@ -6,7 +6,6 @@
 #include "keystone-sbi-arg.h"
 #include "keystone_user.h"
 #include <linux/uaccess.h>
-#include <keystone_user.h>
 
 int __keystone_destroy_enclave(unsigned int ueid);
 


### PR DESCRIPTION
Removed bad include statement that created build error.