### PR TITLE
Pass in EID virtual address to create_enclave

### DIFF
--- a/keystone-ioctl.c
+++ b/keystone-ioctl.c
@@ -73,7 +73,7 @@ int keystone_finalize_enclave(unsigned long arg)
   create_args.params = enclp->params;
 
   // SM will write the eid to struct enclave.eid
-  create_args.eid_vptr = (unsigned int *)&enclave->eid;
+  create_args.eid_vptr = &enclave->eid;
 
   ret = SBI_CALL_1(SBI_SM_CREATE_ENCLAVE, __pa(&create_args));
   if (ret) {

--- a/keystone-ioctl.c
+++ b/keystone-ioctl.c
@@ -73,7 +73,7 @@ int keystone_finalize_enclave(unsigned long arg)
   create_args.params = enclp->params;
 
   // SM will write the eid to struct enclave.eid
-  create_args.eid_pptr = (unsigned int *) __pa(&enclave->eid);
+  create_args.eid_vptr = (unsigned int *)&enclave->eid;
 
   ret = SBI_CALL_1(SBI_SM_CREATE_ENCLAVE, __pa(&create_args));
   if (ret) {

--- a/keystone-sbi-arg.h
+++ b/keystone-sbi-arg.h
@@ -28,7 +28,7 @@ struct keystone_sbi_create_t
   struct runtime_params_t params;
 
   // Outputs from the creation process
-  unsigned int* eid_pptr;
+  unsigned int* eid_vptr;
 };
 
 #endif

--- a/keystone-sbi-arg.h
+++ b/keystone-sbi-arg.h
@@ -28,7 +28,7 @@ struct keystone_sbi_create_t
   struct runtime_params_t params;
 
   // Outputs from the creation process
-  unsigned int* eid_vptr;
+  uint64_t* eid_vptr;
 };
 
 #endif

--- a/keystone.h
+++ b/keystone.h
@@ -80,7 +80,7 @@ struct utm {
 
 struct enclave
 {
-  unsigned long eid;
+  uint64_t eid;
   int close_on_pexit;
   struct utm* utm;
   struct epm* epm;


### PR DESCRIPTION
We can use MPRV with the virtual address instead of directly dereferencing the physical address, for a more safe interface