### PR TITLE
Fix declaration after statement warning

### DIFF
--- a/keystone-ioctl.c
+++ b/keystone-ioctl.c
@@ -257,7 +257,8 @@ int keystone_release(struct inode *inode, struct file *file) {
   }
 
   /* We need to send destroy enclave just the eid to close. */
-    struct enclave *enclave = get_enclave_by_id(ueid);
+  struct enclave *enclave;
+  enclave = get_enclave_by_id(ueid);
 
   if (!enclave) {
     /* If eid is set to the invalid id, then we do not do anything. */


### PR DESCRIPTION
Fixes the following warning that pops up when running the tests

/home/keystone/keystone/hifive-work/linux-keystone-driver/keystone-ioctl.c: In function 'keystone_release':
/home/keystone/keystone/hifive-work/linux-keystone-driver/keystone-ioctl.c:261:5: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
     struct enclave *enclave = get_enclave_by_id(ueid);
     ^~~~~~