### PR TITLE
Improve error handling (further)

### DIFF
--- a/keystone-ioctl.c
+++ b/keystone-ioctl.c
@@ -108,8 +108,8 @@ int keystone_run_enclave(unsigned long data)
   }
 
   if (enclave->eid < 0) {
-    keystone_warn("keystone_run_enclave: skipping (enclave does not exist)\n");
-    return 0;
+    keystone_err("real enclave does not exist\n");
+    return -EINVAL;
   }
 
   ret = sbi_sm_run_enclave(enclave->eid);
@@ -176,17 +176,16 @@ int __keystone_destroy_enclave(unsigned int ueid)
     return -EINVAL;
   }
 
-  if (enclave->eid < 0) {
+  if (enclave->eid >= 0) {
+    ret = sbi_sm_destroy_enclave(enclave->eid);
+    if (ret.error) {
+      keystone_err("fatal: cannot destroy enclave: SBI failed with error code %ld\n", ret.error);
+      return -EINVAL;
+    }
+  } else {
     keystone_warn("keystone_destroy_enclave: skipping (enclave does not exist)\n");
-    return 0;
   }
 
-  ret = sbi_sm_destroy_enclave(enclave->eid);
-
-  if (ret.error) {
-    keystone_err("fatal: cannot destroy enclave: SBI failed with error code %ld\n", ret.error);
-    return -EINVAL;
-  }
 
   destroy_enclave(enclave);
   enclave_idr_remove(ueid);
@@ -209,8 +208,8 @@ int keystone_resume_enclave(unsigned long data)
   }
 
   if (enclave->eid < 0) {
-    keystone_warn("keystone_resume_enclave: skipping (enclave does not exist)\n");
-    return 0;
+    keystone_err("real enclave does not exist\n");
+    return -EINVAL;
   }
 
   ret = sbi_sm_resume_enclave(enclave->eid);


### PR DESCRIPTION
I encountered problems while testing Keystone and found most of them are resolved in commit b4dc6cd403a96ca997487890feb60a0ba89b691a and 0dd63b0546e077b837b3444278457e0fcbe84af4.
However, it seems error handling is not in the best state yet so I'm trying to improve error handling further.

## 1. No valid Keystone enclave should result in error (in general)

On `keystone_run_enclave` and `keystone_resume_enclave`, it just skips when no real Keystone enclave exists. However, while it is an invalid operation, it should return `-EINVAL` instead.

Error message I changed is debatable.

## 2. Destroy operation should release everything related

On destroy operation, we have to release all corresponding resources. However, if we don't have valid enclave ID yet, the original driver does not release user-mode resources including EPM, UTM, enclave UID (managed by Linux kernel's IDR structure) and enclave structure on the Linux kernel-mode driver.